### PR TITLE
Update cache only when required

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: Install required package
   apt:
     name: ssmtp
-    update_cache: yes
+    update_cache: "{{ 'yes' if ssmtp_package_state=='latest' else 'no' }}"
     state: "{{ ssmtp_package_state }}"
 
 - name: Create group for restricted usage of ssmtp


### PR DESCRIPTION
Only update cache when package state is latest. This prevent the task to
always report as changed especially when the package state is set to
present.